### PR TITLE
Fix pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,10 @@ mannrs = 'mannrs.CLI:CLI'
 
 [project]
 name = "mannrs"
-authors = ["Jaime Liew <jaimeliew1@gmail.com>"]
+authors =  [{email = "jaimeliew1@gmail.com"},
+			{name = "Jaime Liew"}]
 readme = "README.md"
-license = "license.md"
+license = {file = "license.md"}
 requires-python = ">=3.6"
 classifiers = [
     "Programming Language :: Rust",


### PR DESCRIPTION
Got errors when installing, e.g. 
  × Preparing editable metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      ðŸ’¥ maturin failed
        Caused by: pyproject.toml is invalid
        Caused by: pyproject.toml is not PEP 517 compliant: invalid type: string "license.md", expected a table with 'file' or 'text' key
      Error running maturin: Command '['maturin', 'pep517', 'write-dist-info', '--metadata-directory', 'C:\\Users\\mmpe\\AppData\\Local\\Temp\\pip-modern-metadata-5h6tf6me', '--interpreter', 'C:\\Anaconda3_2019_10\\envs\\py39\\python.exe']' returned non-zero exit status 1.
      Checking for Rust toolchain....
      Running `maturin pep517 write-dist-info --metadata-directory C:\Users\mmpe\AppData\Local\Temp\pip-modern-metadata-5h6tf6me --interpreter C:\Anaconda3_2019_10\envs\py39\python.exe`
      [end of output]