### PR TITLE
Remove ndarray-linalg dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "mannrs"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "ndarray",
  "ndarray-rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "approx"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,27 +13,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "cauchy"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff11ddd2af3b5e80dd0297fee6e56ac038d9bdc549573cdb51bd6d2efe7f05e"
-dependencies = [
- "num-complex",
- "num-traits",
- "rand",
- "serde",
-]
-
-[[package]]
-name = "cblas-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6feecd82cce51b0204cf063f0041d69f24ce83f680d87514b004248e7b0fa65"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "cfg-if"
@@ -98,26 +68,6 @@ checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
-]
-
-[[package]]
-name = "dirs"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -179,39 +129,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lapack"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7f0050af10913bc5e4f6091df38870cb5d4e45094d3dd551c1aff9d1d59b26"
-dependencies = [
- "lapack-sys",
- "libc",
- "num-complex",
-]
-
-[[package]]
-name = "lapack-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1d3a8a9f07310243de6c6226f039f14bce8d2f4c96b5d30ddbcfa31eb4e94ad"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "lax"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e49ff5bbaf07352b492b17aab73a86871f0c6029f427035fd0562cd0df573c8a"
-dependencies = [
- "cauchy",
- "lapack",
- "num-traits",
- "openblas-src",
- "thiserror",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,7 +160,6 @@ name = "mannrs"
 version = "1.0.0"
 dependencies = [
  "ndarray",
- "ndarray-linalg",
  "ndarray-rand",
  "ndrustfft",
  "num",
@@ -275,30 +191,12 @@ version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec23e6762830658d2b3d385a75aa212af2f67a4586d4442907144f3bb6a1ca8"
 dependencies = [
- "approx",
- "cblas-sys",
- "libc",
  "matrixmultiply",
  "num-complex",
  "num-integer",
  "num-traits",
  "rawpointer",
  "rayon",
-]
-
-[[package]]
-name = "ndarray-linalg"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6953b6c18697bc401c596b885350ea56a696da46415a10a6ed22f2a2e3d78d74"
-dependencies = [
- "cauchy",
- "lax",
- "ndarray",
- "num-complex",
- "num-traits",
- "rand",
- "thiserror",
 ]
 
 [[package]]
@@ -355,8 +253,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
 dependencies = [
  "num-traits",
- "rand",
- "serde",
 ]
 
 [[package]]
@@ -431,27 +327,6 @@ name = "once_cell"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
-
-[[package]]
-name = "openblas-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ecb601fc56534b17316cec4a4d8c848840f2c6744538a4e0fd3833d24f2e8f"
-dependencies = [
- "thiserror",
- "walkdir",
-]
-
-[[package]]
-name = "openblas-src"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a0967b308cab5942eb908b4737385719bef9e1b4953614a0e9d26ad5d41c69"
-dependencies = [
- "dirs",
- "openblas-build",
- "vcpkg",
-]
 
 [[package]]
 name = "parking_lot"
@@ -675,16 +550,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
-dependencies = [
- "getrandom",
- "redox_syscall",
-]
-
-[[package]]
 name = "rustfft"
 version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,25 +564,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "serde"
-version = "1.0.135"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf9235533494ea2ddcdb794665461814781c53f19d87b76e571a1c35acbad2b"
 
 [[package]]
 name = "smallvec"
@@ -743,26 +593,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "transpose"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,23 +615,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "walkdir"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
-dependencies = [
- "same-file",
- "winapi",
- "winapi-util",
-]
-
-[[package]]
 name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,15 +635,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mannrs"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2018"
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ numpy = "0.15.0"
 ndarray-rand = "0.14.0"
 num = "0.4.0"
 ndrustfft = "0.1.6"
-ndarray-linalg = { version = "0.14.1", features = ["openblas-system"] }
 
 
 [package.metadata.docs.rs]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@ pub use self::utilities::Utilities;
 use ndarray::parallel::prelude::*;
 use ndarray::prelude::*;
 use ndarray::Zip;
-use ndarray_linalg::Norm;
 use ndrustfft::Complex;
 use numpy::c32;
 use std::f32::consts::PI;
@@ -76,7 +75,8 @@ pub fn stencilate_sinc_par(
             for (j, mut column) in slice.outer_iter_mut().enumerate() {
                 for (k, mut component) in column.outer_iter_mut().enumerate() {
                     let K = &[Kx[i], Ky[j], Kz[k]];
-                    if arr1(K).norm_l2() < 3.0 / L {
+                    let norm = K.iter().fold(0.0, |acc, &x| acc + x * x);
+                    if norm < 3.0 / L {
                         component.assign(&tensor_gen_sinc.decomp(K));
                     } else {
                         component.assign(&tensor_gen.decomp(K));
@@ -210,7 +210,8 @@ pub fn stencilate_sinc(
             for (j, mut column) in slice.outer_iter_mut().enumerate() {
                 for (k, mut component) in column.outer_iter_mut().enumerate() {
                     let K = &[Kx[i], Ky[j], Kz[k]];
-                    if arr1(K).norm_l2() < 3.0 / L {
+                    let norm = K.iter().fold(0.0, |acc, &x| acc + x * x);
+                    if norm < 3.0 / L {
                         component.assign(&tensor_gen_sinc.decomp(K));
                     } else {
                         component.assign(&tensor_gen.decomp(K));
@@ -390,7 +391,9 @@ pub fn partial_forgetful_turbulate_par(
             for (j, mut column) in slice.outer_iter_mut().enumerate() {
                 for (k, mut component) in column.outer_iter_mut().enumerate() {
                     let K = &[Kx[i], Ky[j], Kz[k]];
-                    let invol: bool = arr1(K).norm_l2() < 3.0 / L;
+                    let norm = K.iter().fold(0.0, |acc, &x| acc + x * x);
+
+                    let invol: bool = norm < 3.0 / L;
 
                     let coef: Array2<f32> = match invol {
                         true => tensor_gen_sinc.decomp(K),
@@ -470,7 +473,9 @@ pub fn partial_forgetful_turbulate(
             for (j, mut column) in slice.outer_iter_mut().enumerate() {
                 for (k, mut component) in column.outer_iter_mut().enumerate() {
                     let K = &[Kx[i], Ky[j], Kz[k]];
-                    let invol: bool = arr1(K).norm_l2() < 3.0 / L;
+                    let norm = K.iter().fold(0.0, |acc, &x| acc + x * x);
+
+                    let invol: bool = norm < 3.0 / L;
 
                     let coef: Array2<f32> = match invol {
                         true => tensor_gen_sinc.decomp(K),

--- a/src/python_interface.rs
+++ b/src/python_interface.rs
@@ -1,15 +1,11 @@
 use ndarray::{Array1, Array3, Array5};
-use numpy::{
-    c32, PyArray1, PyArray2, PyArray3, PyArray4, PyArray5, PyReadonlyArray1, PyReadonlyArray5,
-    ToPyArray,
-};
+use numpy::{c32, PyArray1, PyArray2, PyArray3, PyReadonlyArray1, ToPyArray};
 use pyo3::prelude::*;
 
 use crate::{
     forgetful_turbulate, forgetful_turbulate_par, partial_forgetful_turbulate,
     partial_forgetful_turbulate_par, partial_turbulate, partial_turbulate_par, stencilate_sinc,
-    stencilate_sinc_par, turbulate, turbulate_par, turbulate_unit, Tensors::*,
-    Utilities::complex_random_gaussian, Utilities::freq_components,
+    stencilate_sinc_par, turbulate, turbulate_par, Tensors::*, Utilities::freq_components,
 };
 
 #[pyclass]

--- a/src/tensors.rs
+++ b/src/tensors.rs
@@ -255,7 +255,7 @@ pub mod Tensors {
 
             for i in 0..3 {
                 for j in 0..=i {
-                    let mut sum = if i == j {
+                    let sum = if i == j {
                         let mut s = 0.0;
                         for k in 0..j {
                             s += l[[j, k]] * l[[j, k]];


### PR DESCRIPTION
The inclusion of  ndarray-linalg as a dependency increases the difficulty of installation due to the dependence on LAPACK. As ndarray-linalg is only used in mann.rs for a 3x3 Cholesky decomposition and some matrix norms, it should be possible to replace the ndarray-linalg functions with pure rust implementations. This will allow ndarray-linalg to be removed from the dependencies, greatly reducing compilation time and simplifying installation on all platforms.